### PR TITLE
Remove deprecated function

### DIFF
--- a/evil-easymotion.el
+++ b/evil-easymotion.el
@@ -92,14 +92,13 @@
   (let* ((avy-style (or evilem-style avy-style))
          (avy-keys (or evilem-keys avy-keys))
          (avy-all-windows nil))
-    (avy--goto
-     (avy--process
-      (mapcar
-       (lambda (pt)
-         (cons (cons pt pt)
-               (get-buffer-window)))
-       collector)
-      (avy--style-fn avy-style)))))
+    (avy--process
+     (mapcar
+      (lambda (pt)
+        (cons (cons pt pt)
+              (get-buffer-window)))
+      collector)
+     (avy--style-fn avy-style))))
 
 (defun evilem-collect (func)
   "Repeatedly execute func, and collect the cursor positions into a list"

--- a/evil-easymotion.el
+++ b/evil-easymotion.el
@@ -6,7 +6,7 @@
 ;; Keywords: convenience, evil
 ;; Version: 20141205
 ;; URL: https://github.com/pythonnut/evil-easymotion.el
-;; Package-Requires: ((emacs "24") (avy "20150508.1418"))
+;; Package-Requires: ((emacs "24") (avy "0.3.0"))
 
 ;;; License:
 


### PR DESCRIPTION
Now it is alias of identity so we can remove it. And update minimum avy version.

See
- https://github.com/abo-abo/avy/blob/d439b9d44faa08e15a328075d1473d869d79f284/avy.el#L1131-L1134
- https://github.com/abo-abo/avy/commit/1d1e4b62e810c042c6f06ae2b0cb6ef882ffb5c2