### PR TITLE
Fix: evilem motion forward word end stopping at single letters

### DIFF
--- a/evil-easymotion.el
+++ b/evil-easymotion.el
@@ -185,10 +185,12 @@
 
 (eval-and-compile
   (defun evilem--compute-inclusivity (funcs)
-    (when (and (= (length funcs) 1)
-               (evil-has-command-properties-p (car funcs)))
-      `(setq evil-this-type
-             ',(evil-get-command-property (car funcs) :type)))))
+    (cond ((symbolp funcs) `(setq evil-this-type
+                                  ',(evil-get-command-property funcs :type)))
+
+          ((and (listp funcs) (= (length funcs) 1)) (evilem--compute-inclusivity (car funcs)))
+
+          ((and (listp funcs) (= (length funcs) 2) (eq (car funcs) 'function)) (evilem--compute-inclusivity (cdr funcs))))))
 
 (cl-defmacro evilem-make-motion (name
                                  funcs

--- a/evil-easymotion.el
+++ b/evil-easymotion.el
@@ -134,7 +134,8 @@
             ;; make sure the motion doesn't move the window
             (scroll-conservatively 101)
             (smooth-scrolling-mode nil)
-            (scroll-margin 0))
+            (scroll-margin 0)
+            (evil-state 'normal))
     (if (functionp func)
         (avy-dowindows current-prefix-arg
           (save-excursion


### PR DESCRIPTION
Couple of fixes:

### call `evilem--compute-inclusivity` with the name of the function: fixes several evilem motions not respecting the inclusive/exclusive rules of the evil movement

During the macro expantion of

    (evilem-make-motion evilem-motion-some #'evil-some-motion)

the function quote argument becomes `(funcion . (evil-some-motion . nil))`

This list was being passed to `evilem--compute-inclusivity` , which would try to
take the first element and try to fetch the ` :type property of the evil function
effectively `evil-get-command-property` with the symbol `'function` instead of
`'evil-some-motion`.

This MR fixes the erroneous, keeping backwards compatibility in case
someone anywhere called (evilem--compute-inclusivity '(evil-some-motion))

### make `{word,WORD}-end` movements see past single letters in operator-state

`evilem-motion-forward-{word, WORD}-end` does not collect all targets when called
in operator-state due to a corner case in `evil-forward-word-end`: when
called in operator-state, evil ensures the cursor does not move if it's over
a one-letter word.

As a result, `evilem--collect`'s repeated calls to forward-word-end in operator
state will stop at the first single-letter word inside the line.

For example, `g s e` will place targets on every word as expected:

       cursor
         |
         v
         this is a word
            ^  ^ ^    ^
            |  | |    |
            a  s d    f

But when calling `evilem-motion-forward-word-end` during yank/delete/change, no
targets will be created after "a", as `evilem--collect` stops after
`evil-forward-word-end` refused to move the cursor in "a". For example, pressing `y g s e` in
the example below will not place any target at "word" or any text afterwards:

       cursor
         |
         v
         this is a word
            ^  ^ ^
            |  | |
            a  s d

This MR fixes this behavior by temporarily setting evil-state to 'motion
while collecting targets.